### PR TITLE
Add timeout to CI tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,7 @@ on:
 jobs:
   verify-tomls:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/ci/bun/scripts/verifyTomls.ts
+++ b/ci/bun/scripts/verifyTomls.ts
@@ -156,6 +156,7 @@ async function verifySnippet(snippet: Snippet): Promise<VerificationResult> {
 
   const overallSuccess = configValid || usersValid;
   if (overallSuccess) {
+    console.log(`${snippet.file}:${snippet.line} verified successfully`);
     return { success: true };
   }
 


### PR DESCRIPTION
also add per-snippet logs to that progress can be tracked.