### PR TITLE
fix load_balancing_strategy typo in docs

### DIFF
--- a/docs/features/load-balancer/index.md
+++ b/docs/features/load-balancer/index.md
@@ -45,7 +45,7 @@ Round robin is used **by default**, so no config changes are required. You can s
 
 ```toml
 [general]
-load_balancer_strategy = "round_robin"
+load_balancing_strategy = "round_robin"
 ```
 
 ### Random
@@ -58,7 +58,7 @@ This algorithm is often effective when queries have unpredictable runtime. By ra
 
 ```toml
 [general]
-load_balancer_strategy = "random"
+load_balancing_strategy = "random"
 ```
 
 ### Least active connections
@@ -71,7 +71,7 @@ This algorithm is useful when you want to "bin pack" the replica cluster. It ass
 
 ```toml
 [general]
-load_balancer_strategy = "least_active_connections"
+load_balancing_strategy = "least_active_connections"
 ```
 
 


### PR DESCRIPTION
load_balancer_strategy is never referenced in the current code on main branch, however `load_balancing_strategy` is.

Update docs to avoid confusion and misconfiguration.