### PR TITLE
docs(general): document jemalloc_background_thread option

### DIFF
--- a/docs/configuration/pgdog.toml/general.md
+++ b/docs/configuration/pgdog.toml/general.md
@@ -632,6 +632,16 @@ Available options:
 
 Default: **`abort`**
 
+## Memory
+
+### `jemalloc_background_thread`
+
+Enable jemalloc's background purge threads so freed memory is returned to the OS after bursts of large allocations, instead of accumulating as retained dirty pages. Equivalent to setting the `_RJEM_MALLOC_CONF=background_thread:true` environment variable, without requiring it.
+
+Has no effect on builds where jemalloc is not the active allocator (e.g. `msvc`).
+
+Default: **`false`** (disabled)
+
 ## Logging
 
 ### `log_format`


### PR DESCRIPTION
Documents the `jemalloc_background_thread` `[general]` option added in pgdogdev/pgdog#1260 — adds a **Memory** section to the general config reference (`configuration/pgdog.toml/general/#jemalloc_background_thread`), the anchor the code's doc-comment links to.

Refs pgdogdev/pgdog#1230.
