### PR TITLE
docs(general): document query_cache_memory_limit and query_cache_idle_timeout

### DIFF
--- a/docs/administration/config.md
+++ b/docs/administration/config.md
@@ -45,9 +45,9 @@ The following configuration parameters are available and their current values:
 | `prepared_statements` [:material-link:](../configuration/pgdog.toml/general.md#prepared_statements) | `extended` |
 | `prepared_statements_limit` [:material-link:](../configuration/pgdog.toml/general.md#prepared_statements_limit) | `500` |
 | `pub_sub_channel_size` [:material-link:](../configuration/pgdog.toml/general.md#pub_sub_channel_size) | `4098` |
+| `query_cache_idle_timeout` [:material-link:](../configuration/pgdog.toml/general.md#query_cache_idle_timeout) | `0` |
 | `query_cache_limit` | `500` |
 | `query_cache_memory_limit` [:material-link:](../configuration/pgdog.toml/general.md#query_cache_memory_limit) | `0` |
-| `query_cache_ttl` [:material-link:](../configuration/pgdog.toml/general.md#query_cache_ttl) | `0` |
 | `query_log` | `default` |
 | `query_timeout` [:material-link:](../configuration/pgdog.toml/general.md#query_timeout) | `1s` |
 | `read_write_split` [:material-link:](../configuration/pgdog.toml/general.md#read_write_split) | `include_primary` |

--- a/docs/administration/config.md
+++ b/docs/administration/config.md
@@ -46,6 +46,8 @@ The following configuration parameters are available and their current values:
 | `prepared_statements_limit` [:material-link:](../configuration/pgdog.toml/general.md#prepared_statements_limit) | `500` |
 | `pub_sub_channel_size` [:material-link:](../configuration/pgdog.toml/general.md#pub_sub_channel_size) | `4098` |
 | `query_cache_limit` | `500` |
+| `query_cache_memory_limit` [:material-link:](../configuration/pgdog.toml/general.md#query_cache_memory_limit) | `0` |
+| `query_cache_ttl` [:material-link:](../configuration/pgdog.toml/general.md#query_cache_ttl) | `0` |
 | `query_log` | `default` |
 | `query_timeout` [:material-link:](../configuration/pgdog.toml/general.md#query_timeout) | `1s` |
 | `read_write_split` [:material-link:](../configuration/pgdog.toml/general.md#read_write_split) | `include_primary` |

--- a/docs/configuration/pgdog.toml/general.md
+++ b/docs/configuration/pgdog.toml/general.md
@@ -474,6 +474,21 @@ Limit on the number of statements saved in the statement cache used to accelerat
 
 Default: **`1_000`**
 
+### `query_cache_memory_limit`
+
+Approximate memory budget, in bytes, for the statement cache. Entries are evicted in LRU order once the sum of their sizes exceeds the budget. Unlike the count-based [`query_cache_limit`](#query_cache_limit), this bounds memory usage regardless of query size and complexity. Setting this to `0` disables the memory cap.
+
+!!! note
+    Entry sizes are measured with jemalloc. On builds without jemalloc, the budget is approximated from query text length.
+
+Default: **`0`** (disabled)
+
+### `query_cache_ttl`
+
+Time-to-idle, in seconds, for statement cache entries. An entry not accessed within this window is removed by the maintenance sweep. Setting this to `0` disables idle expiry.
+
+Default: **`0`** (disabled)
+
 ### `query_parser_enabled`
 
 !!! warning "Deprecated setting"

--- a/docs/configuration/pgdog.toml/general.md
+++ b/docs/configuration/pgdog.toml/general.md
@@ -483,9 +483,9 @@ Approximate memory budget, in bytes, for the statement cache. Entries are evicte
 
 Default: **`0`** (disabled)
 
-### `query_cache_ttl`
+### `query_cache_idle_timeout`
 
-Time-to-idle, in seconds, for statement cache entries. An entry not accessed within this window is removed by the maintenance sweep. Setting this to `0` disables idle expiry.
+Idle timeout, in milliseconds, for statement cache entries. An entry not accessed within this window is removed by the maintenance sweep. Setting this to `0` disables idle expiry.
 
 Default: **`0`** (disabled)
 


### PR DESCRIPTION
Documents the two `[general]` options added in pgdogdev/pgdog#1266:

- **`query_cache_memory_limit`** — byte budget for the query (AST) cache, LRU eviction once the summed entry size exceeds it; complements the count-based `query_cache_limit`.
- **`query_cache_idle_timeout`** — idle timeout in milliseconds; entries not accessed within the window are dropped by the maintenance sweep.

Both default to `0` (off). Adds reference entries in the general config page (the anchors the code's doc-comments link to) and the two rows in the SHOW CONFIG table.

Companion to pgdogdev/pgdog#1266 — should merge together with it (or be closed if that PR is declined).