### PR TITLE
fix: clipboard toast text invisible on inverted background

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -217,6 +217,10 @@
   line-height: 1.75;
   color: var(--pg-text);
 }
+/* The clipboard toast sits on an inverted background, so invert its text too. */
+.md-dialog__inner.md-typeset {
+  color: var(--md-default-bg-color);
+}
 .md-typeset h1 {
   font-size: 1.9rem;
   font-weight: 800;


### PR DESCRIPTION
This PR fixes the "Copied to clipboard" toast rendering as an empty box.

**Before:** The toast text was the same color as its background, so it was invisible.

<img width="692" height="441" alt="image" src="https://github.com/user-attachments/assets/b7e56a62-ed8a-44cb-9990-1f5152bb85ae" />


**After:** The text is readable in both light and dark mode.

<img width="592" height="373" alt="image" src="https://github.com/user-attachments/assets/7d5d20da-4633-47a7-8e4c-04d5c0e918bc" />

